### PR TITLE
retroarch - only set video_threaded to true on non x86 systems

### DIFF
--- a/scriptmodules/emulators/retroarch.sh
+++ b/scriptmodules/emulators/retroarch.sh
@@ -149,7 +149,11 @@ function configure_retroarch() {
     iniSet "config_save_on_exit" "false"
     iniSet "video_aspect_ratio_auto" "true"
     iniSet "video_smooth" "false"
-    iniSet "video_threaded" "true"
+
+    if ! isPlatform "x86"; then
+        iniSet "video_threaded" "true"
+    fi
+
     iniSet "video_font_size" "12"
     iniSet "core_options_path" "$configdir/all/retroarch-core-options.cfg"
     isPlatform "x11" && iniSet "video_fullscreen" "true"


### PR DESCRIPTION
 * fixes issue with black screen on x86/opengl
 * on faster machines the setting is best off - "Using this might improve performance at possible cost of latency and more video stuttering."